### PR TITLE
V1.1.3- Action bubbling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-fetchy-middleware",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Fetch wrapping middleware for Redux",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,10 @@ function reduxFetchy(config){
             return next(action);
         }
 
+        if(meta.bubbles) {
+            next(action);
+        }
+
         const {url, fetchOptions} = payload;
 
         const {pendingSuffix, resolvedSuffix, rejectedSuffix, fetcher} = baseConfig;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -71,6 +71,19 @@ describe('redux-fetchy-middleware', ()=>{
             fetchStub.should.have.been.called;
             fetchStub.should.have.been.calledWith('www.foo.bar');
         })
+
+        it('can bubble actions', ()=>{
+            let nextSpy = sinon.spy((action)=>{});
+            let dispatchSpy = sinon.spy((action)=>{});
+            let fetchStub = sinon.spy((url)=>{return new Promise(resolve=>resolve())});
+      
+            const middleware = reduxFetchy({fetcher: fetchStub});
+            middleware({dispatch: dispatchSpy})(nextSpy)({type: 'GET_DATA', meta: {fetch: true, bubbles: true}, payload: {url: 'www.foo.bar'}});
+
+            nextSpy.should.have.been.calledOnce;            
+            dispatchSpy.should.have.been.called;                        
+            fetchStub.should.have.been.called;
+        })
     })
 
     describe('dispatches status updates', ()=>{


### PR DESCRIPTION
Allow fetch actions to optionally continue through the middleware pipeline using a bubble option in the meta